### PR TITLE
fix comments in string while parsing

### DIFF
--- a/src/grammar/ini_lexer.l
+++ b/src/grammar/ini_lexer.l
@@ -45,19 +45,16 @@ blank [ \t]
     iniloc.step();
 %}
 
-{blank}+    iniloc.step();
-[\n]        {iniloc.lines(1); return Kitsune::Ini::IniParser::make_LINEBREAK (iniloc);}
-"="         return Kitsune::Ini::IniParser::make_EQUAL (iniloc);
-"["         return Kitsune::Ini::IniParser::make_BRACKOPEN (iniloc);
-"]"         return Kitsune::Ini::IniParser::make_BRACKCLOSE (iniloc);
-","         return Kitsune::Ini::IniParser::make_COMMA (iniloc);
 
-#(\\.|[^"\\])*\n {
-    iniloc.step();
-}
-
+{blank}+    if(Kitsune::Ini::IniParserInterface::m_outsideComment) { iniloc.step();  } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
+[\n]        {iniloc.lines(1); return Kitsune::Ini::IniParser::make_LINEBREAK (iniloc); }
+"="         if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_EQUAL (iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
+"["         if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_BRACKOPEN (iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
+"]"         if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_BRACKCLOSE (iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
+","         if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_COMMA (iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
+"#"         if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_COMMENT (iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 \"(\\.|[^"\\])*\" {
-    return Kitsune::Ini::IniParser::make_STRING(yytext, iniloc);
+            if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_STRING(yytext, iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 }
 
 
@@ -70,22 +67,22 @@ blank [ \t]
     {
         driver.error(iniloc, "integer is out of range");
     }
-    return Kitsune::Ini::IniParser::make_NUMBER (length, iniloc);
+    if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_NUMBER (length, iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 }
 
 {int}+"."{int}*	{
     float value = atof( yytext );
-    return Kitsune::Ini::IniParser::make_FLOAT(value, iniloc);
+    if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_FLOAT(value, iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 }
 
-{id}       return Kitsune::Ini::IniParser::make_IDENTIFIER(yytext, iniloc);
+{id} if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_IDENTIFIER(yytext, iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 
 
 [a-zA-Z_0-9|\-|.]* {
-    return Kitsune::Ini::IniParser::make_STRING_PLN(yytext, iniloc);
+    if(Kitsune::Ini::IniParserInterface::m_outsideComment) { return Kitsune::Ini::IniParser::make_STRING_PLN(yytext, iniloc); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 }
 
-.          driver.error(iniloc, "invalid character");
+.          if(Kitsune::Ini::IniParserInterface::m_outsideComment) { driver.error(iniloc, "invalid character"); } else { return Kitsune::Ini::IniParser::make_DEFAULTRULE(yytext, iniloc); }
 <<EOF>>    return Kitsune::Ini::IniParser::make_END(iniloc);
 
 %%

--- a/src/grammar/ini_parser.y
+++ b/src/grammar/ini_parser.y
@@ -66,9 +66,10 @@ YY_DECL;
     BRACKOPEN "["
     BRACKCLOSE "]"
     COMMA ","
+    COMMENT "#"
 ;
 
-
+%token <std::string> DEFAULTRULE "defaultrule"
 %token <std::string> IDENTIFIER "identifier"
 %token <std::string> STRING "string"
 %token <std::string> STRING_PLN "string_pln"
@@ -186,11 +187,33 @@ identifierlist:
         $$ = tempItem;
     }
 
+commentline:
+   comment  defaultroute  "lbreak"
+   {
+        IniParserInterface::m_outsideComment = true;
+   }
+
+comment:
+   "#"
+   {
+        IniParserInterface::m_outsideComment = false;
+   }
 
 linebreaks:
+   linebreaks "lbreak" commentline
+|
    linebreaks "lbreak"
 |
+   "lbreak" commentline
+|
    "lbreak"
+
+defaultroute:
+   defaultroute "defaultrule"
+|
+   "defaultrule"
+|
+   %empty
 
 %%
 

--- a/src/ini_parsing/ini_parser_interface.cpp
+++ b/src/ini_parsing/ini_parser_interface.cpp
@@ -21,6 +21,8 @@ namespace Ini
 {
 using Common::splitStringByDelimiter;
 
+bool IniParserInterface::m_outsideComment = true;
+
 /**
  * The class is the interface for the bison-generated parser.
  * It starts the parsing-process and store the returned values.

--- a/src/ini_parsing/ini_parser_interface.h
+++ b/src/ini_parsing/ini_parser_interface.h
@@ -49,6 +49,9 @@ public:
                const std::string& message);
     std::string getErrorMessage() const;
 
+    // static variables, which are used in lexer and parser
+    static bool m_outsideComment;
+
 private:
     DataItem* m_output;
     std::string m_errorMessage = "";

--- a/tests/libKitsuneIni/ini_item_test.cpp
+++ b/tests/libKitsuneIni/ini_item_test.cpp
@@ -33,7 +33,7 @@ void
 IniItem_Test::parse_test()
 {
     IniItem object;
-    std::pair<bool, std::string> result = object.parse(getTestString());
+    std::pair<bool, std::string> result = object.parse(getTestString(), true);
 
     UNITTEST(result.first, true);
     std::cout<<"result.second: "<<result.second<<std::endl;
@@ -189,8 +189,9 @@ IniItem_Test::getTestString()
                 "asdf = asdf.asdf\n"
                 "id = 550e8400-e29b-11d4-a716-446655440000\n"
                 "x = 2\n"
-                "\n"
+                "\n\n"
                 "[hmmm]\n"
+                "# this is only a simple 0815 testcommit\n\n"
                 "poi_poi = 1.300000\n"
                 "\n");
     return testString;


### PR DESCRIPTION
Comments in the parsing string were not only not tested, they were totally
broken. Based on my parsing trick from libKitsuneJinja2-parser, I fixed
this with a default-rule for all input after a comment-character unit
a linebreak. Also added this in the tests.

close #11